### PR TITLE
adding benchmark file - in progress

### DIFF
--- a/project-code/hadoop-python-docker-sentiment/benchmark.md
+++ b/project-code/hadoop-python-docker-sentiment/benchmark.md
@@ -1,0 +1,59 @@
+# Running time for sentiment analysis hadoop version 2.9.0
+
+| #worker | rounds | mbp     | centos | ubuntu(vb) | Pi |
+|---------|--------|---------|--------|------------|----|
+| pseudo  | 1      | 99m25s  | 83m34s |            |    |
+|         | 2      | 100m33s | 83m43s |            |    |
+|         | 3      | 97m44s  | 83m47s |            |    |
+| 1       | 1      |         | 83m9s  | 44m30s     |    |
+|         | 2      |         | 83m28s | 45m4s      |    |
+|         | 3      |         |        | 45m1s      |    |
+| 2       | 1      | 106m43s | 84m46s |            |    |
+|         | 2      | 110m20s | 85m4s  |            |    |
+|         | 3      | 109m27s | 84m49s |            |    |
+| 3       | 1      |         | 87m10s |            |    |
+|         | 2      |         | 86m48s |            |    |
+|         | 3      |         | 86m47s |            |    |
+| 4       | 1      |         | 87m30s |            |    |
+|         | 2      |         | 88m15s |            |    |
+|         | 3      |         | 88m2s  |            |    |
+
+
+
+# Information about the machine:
+
+
+## Min's mbp
+
+* MacBook Pro (Retina, 13-inch, Early 2015) 
+* 2.7 GHz Intel Core i5
+* 2 Core
+* 8G memory
+* macOS High Sierra 10.13.3
+
+## Min's centos
+
+* Acer Aspire 4830
+* Intel(R) Core(TM) i5-2430M CPU @2.40GHz
+* 2 Core
+* 16G memory
+* centOS 
+
+## Min's Ubuntu VirtualBox
+
+### Host machine info
+
+* Asus Desktop
+* Intel(R) Core(TM) i5-4690K CPU @3.50GHz
+* 4 Cores
+* 16G memory
+* windows7
+
+### VirutualBox allocation
+
+* 11G base memory
+* 2 base Core
+
+
+
+


### PR DESCRIPTION
Hi Bertolt

I just checked in a file that I created benchmarking the running time across different machines with different cluster set-ups (such as pseudo-distributed, 1 worker, 2 worker, etc), the machines I have are two laptops (one centos, one mac), one desktop(windows7) running virtualbox of Ubuntu. Some of the test has been done and you can see the results. (some interesting patterns actually)

We would later add Pi, and echo etc to compare as well. Please be aware of this table. 
Thanks